### PR TITLE
chore: remove ocurrence order plugin

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -216,10 +216,6 @@ module.exports = function makeWebpackConfig(ENV) {
             // Dedupe modules in the output
             new webpack.optimize.DedupePlugin(),
 
-            // Reference: http://webpack.github.io/docs/list-of-plugins.html#occurrenceorderplugin
-            // Assign the module and chunk ids by occurrence count.
-            new webpack.optimize.OccurrenceOrderPlugin(),
-
             // Reference: http://webpack.github.io/docs/list-of-plugins.html#uglifyjsplugin
             // Minify all javascript, switch loaders to minimizing mode
             new webpack.optimize.UglifyJsPlugin(),


### PR DESCRIPTION
It is not longer needed in webpack 2.