### PR TITLE
chore: remove test check for ETP

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -201,7 +201,7 @@ module.exports = function makeWebpackConfig(ENV) {
             // Extract css files
             // Reference: https://github.com/webpack/extract-text-webpack-plugin
             // Disabled when in test mode or not in build mode
-            new ExtractTextPlugin('css/[name].css', {disable: ENV !== 'prod' || ENV === 'test'})
+            new ExtractTextPlugin('css/[name].css', {disable: ENV !== 'prod'})
         );
     }
 


### PR DESCRIPTION
Since the whole block is only processed if we are outside test, that check is not needed anymore.