### PR TITLE
Update to Angular 2 beta 6

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,15 +19,15 @@
     "ci": "npm run e2e && npm run test",
     "docs": "typedoc --options typedoc.json src/app/app.ts",
     "start": "npm run server",
-    "postinstall": "npm run webdriver-update"
+    "postinstall": "npm run webdriver-update && typings install"
   },
   "dependencies": {
-    "angular2": "2.0.0-beta.3",
+    "angular2": "2.0.0-beta.6",
     "es6-promise": "^3.0.2",
     "es6-shim": "^0.33.3",
     "reflect-metadata": "0.1.2",
     "rxjs": "5.0.0-beta.0",
-    "zone.js": "0.5.11"
+    "zone.js": "0.5.14"
   },
   "devDependencies": {
     "angular-cli": "0.0.*",
@@ -63,6 +63,7 @@
     "tslint-loader": "^2.1.0",
     "typedoc": "^0.3.12",
     "typescript": "^1.7.3",
+    "typings": "^0.6.8",
     "url-loader": "^0.5.6",
     "webpack": "^2.0.7-beta",
     "webpack-dev-server": "^2.0.0-beta"

--- a/src/bootstrap.ts
+++ b/src/bootstrap.ts
@@ -1,5 +1,4 @@
-// jasmine typings to avoid warnings in beta.2
-/// <reference path="../node_modules/angular2/typings/jasmine/jasmine.d.ts"/>
+/// <reference path="../typings/main.d.ts"/>
 
 import {enableProdMode, provide} from "angular2/core";
 import {bootstrap, ELEMENT_PROBE_PROVIDERS} from 'angular2/platform/browser';

--- a/typings.json
+++ b/typings.json
@@ -1,0 +1,9 @@
+{
+  "ambientDevDependencies": {
+    "jasmine": "github:DefinitelyTyped/DefinitelyTyped/jasmine/jasmine.d.ts#dd638012d63e069f2c99d06ef4dcc9616a943ee4"
+  },
+  "ambientDependencies": {
+    "es6-shim": "github:DefinitelyTyped/DefinitelyTyped/es6-shim/es6-shim.d.ts#6697d6f7dadbf5773cb40ecda35a76027e0783b2",
+    "node": "github:DefinitelyTyped/DefinitelyTyped/node/node.d.ts#aee0039a2d6686ec78352125010ebb38a7a7d743"
+  }
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -86,7 +86,8 @@ module.exports = function makeWebpackConfig(ENV) {
                         2403, // 2403 -> Subsequent variable declarations
                         2300, // 2300 -> Duplicate identifier
                         2374, // 2374 -> Duplicate number index signature
-                        2375  // 2375 -> Duplicate string index signature
+                        2375, // 2375 -> Duplicate string index signature
+                        2502  // 2502 -> Referenced directly or indirectly
                     ]
                 },
                 exclude: [ENV === 'test' ? /\.(e2e)\.ts$/ : /\.(spec|e2e)\.ts$/, /node_modules\/(?!(ng2-.+))/]


### PR DESCRIPTION
So this update requires more changes.

Angular decided to remove all typings from the core (except 2) that means that we need to type:

Jasmine
es6-shim
require

I would use `require.d.ts` for our requires but we also have a `process` in bootstrap.ts (for the ENV thingy) so I need node typings (that existed on the angular repo as well, but it was for node 0.12).

Installing latest `node.d.ts` gives an error 2502 that I reported here: https://github.com/DefinitelyTyped/DefinitelyTyped/issues/8058

So as a temporary workaround I had to ignore that entry for ts-loader.