### PR TITLE
add module to tsconfig

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "target": "ES5",
+    "module": "commonjs",
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "sourceMap": true


### PR DESCRIPTION
If I am not mistaken, this is the default, but without it the IDEs complains about not finding angular imports.